### PR TITLE
Update VPCMasterTemplate.yaml - Lambda Python Version

### DIFF
--- a/VPCMasterTemplate.yaml
+++ b/VPCMasterTemplate.yaml
@@ -472,7 +472,7 @@ Resources:
                 responseData = {}
                 responseData['SubnetId'] = responseValue
                 cfnresponse.send(event, context, cfnresponse.SUCCESS, responseData, "CustomResourcePhysicalID")
-      Runtime: python3.6
+      Runtime: python3.12
       Role: !GetAtt IPv6WorkaroundRole.Arn
       Timeout: 30
   RTRESERVEDA: 


### PR DESCRIPTION
[cfn-lint] E2533: Runtime 'python3.6' was deprecated on '2022-07-18'. Creation was disabled on '2022-07-18' and update on '2022-08-29'. Please consider updating to 'python3.12'